### PR TITLE
Don't use `git.depth=1` anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,3 @@ script:
 branches:
   only:
     - master
-
-git:
-  depth: 1


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/py-toxcore-c/10)
<!-- Reviewable:end -->
