### PR TITLE
Adapt py-toxcore-c to new conferences state change callback.

### DIFF
--- a/pytox/core.c
+++ b/pytox/core.c
@@ -1511,15 +1511,13 @@ static PyMethodDef Tox_methods[] = {
     "Callback for joins/parts/name changes, default implementation does "
     "nothing.\n\n"
     "There are there possible *change* values:\n\n"
-    "+----------------------------------------------+----------------------+\n"
-    "| change                                       | description          |\n"
-    "+==============================================+======================+\n"
-    "| Tox.CONFERENCE_STATE_CHANGE_PEER_JOIN        | a peer is added      |\n"
-    "+----------------------------------------------+----------------------+\n"
-    "| Tox.CONFERENCE_STATE_CHANGE_PEER_EXIT        | a peer is deleted    |\n"
-    "+----------------------------------------------+----------------------+\n"
-    "| Tox.CONFERENCE_STATE_CHANGE_PEER_NAME_CHANGE | name of peer changed |\n"
-    "+----------------------------------------------+----------------------+\n"
+    "+----------------------------------------------+----------------------------+\n"
+    "| change                                       | description                |\n"
+    "+==============================================+============================+\n"
+    "| Tox.CONFERENCE_STATE_CHANGE_LIST_CHANGED     | a peer is added or removed |\n"
+    "+----------------------------------------------+----------------------------+\n"
+    "| Tox.CONFERENCE_STATE_CHANGE_PEER_NAME_CHANGE | name of peer changed       |\n"
+    "+----------------------------------------------+----------------------------+\n"
   },
   {
     "on_file_recv", (PyCFunction)ToxCore_callback_stub, METH_VARARGS,
@@ -1937,8 +1935,7 @@ void ToxCore_install_dict()
     SET(USER_STATUS_NONE)
     SET(USER_STATUS_AWAY)
     SET(USER_STATUS_BUSY)
-    SET(CONFERENCE_STATE_CHANGE_PEER_JOIN)
-    SET(CONFERENCE_STATE_CHANGE_PEER_EXIT)
+    SET(CONFERENCE_STATE_CHANGE_LIST_CHANGED)
     SET(CONFERENCE_STATE_CHANGE_PEER_NAME_CHANGE)
     SET(FILE_KIND_DATA)
     SET(FILE_KIND_AVATAR)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -532,7 +532,7 @@ class ToxTest(unittest.TestCase):
 
         def on_conference_namelist_change(self, gid, peer_number, change):
             assert gid == group_id
-            assert change == Tox.CONFERENCE_STATE_CHANGE_PEER_JOIN
+            assert change == Tox.CONFERENCE_STATE_CHANGE_LIST_CHANGED
             self.gn = True
 
         AliceTox.on_conference_namelist_change = on_conference_namelist_change


### PR DESCRIPTION
See https://github.com/TokTok/c-toxcore/pull/295.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/py-toxcore-c/22)
<!-- Reviewable:end -->
