### PR TITLE
Avoid LAN discovery in python tests.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,7 +8,10 @@ cc_binary(
         "pytox/*.c",
         "pytox/*.h",
     ]),
-    copts = ["-DENABLE_AV"],
+    copts = [
+        "-DENABLE_AV",
+        "-Wno-strict-aliasing",
+    ],
     linkopts = select({
         "@toktok//tools/config:freebsd": ["-Wl,--version-script,$(location pytox.ld)"],
         "@toktok//tools/config:linux": ["-Wl,--version-script,$(location pytox.ld)"],

--- a/pytox/av.c
+++ b/pytox/av.c
@@ -722,7 +722,7 @@ PyTypeObject ToxAVCoreType = {
     ToxAVCore_new,                 /* tp_new */
 };
 
-void ToxAVCore_install_dict()
+void ToxAVCore_install_dict(void)
 {
 #define SET(name)                                           \
     PyObject* obj_##name = PyLong_FromLong(TOXAV_##name);   \

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -56,6 +56,7 @@ class ToxOptions():
     def __init__(self):
         self.ipv6_enabled = True
         self.udp_enabled = True
+        self.local_discovery_enabled = False
         self.proxy_type = 0  # 1=http, 2=socks
         self.proxy_host = ''
         self.proxy_port = 0
@@ -69,6 +70,9 @@ class ToxOptions():
 
 class AliceTox(Tox):
     def __init__(self, opts):
+        """
+        t:on_log
+        """
         super(AliceTox, self).__init__(opts)
 
         def on_log(self, level, file, line, func, message):
@@ -84,9 +88,17 @@ class BobTox(Tox):
 
 class ToxTest(unittest.TestCase):
     def setUp(self):
+        """
+        t:bootstrap
+        t:self_get_dht_id
+        t:self_get_udp_port
+        """
         opt = ToxOptions()
         self.alice = AliceTox(opt)
         self.bob = BobTox(opt)
+
+        self.bob.bootstrap("localhost", self.alice.self_get_udp_port(),
+                self.alice.self_get_dht_id())
 
         self.loop_until_connected()
 


### PR DESCRIPTION
So they can run in parallel with other tests that would otherwise make
python tests flaky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/py-toxcore-c/40)
<!-- Reviewable:end -->
