### PR TITLE
Pin CI to Trusty to keep testing things Xenial dropped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+dist: trusty
 language: python
 sudo: false
 


### PR DESCRIPTION
Maybe we should delete some of them, but Travis keeps sending me passive-aggressive emails about how the py-toxcore-c build is still failing and this will get it off my back for a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/py-toxcore-c/46)
<!-- Reviewable:end -->
