### PR TITLE
Use python3 for bazel builds.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,6 +22,6 @@ cc_binary(
     deps = [
         "pytox.ld",
         "//c-toxcore",
-        "@python2//:python",
+        "@python3//:python",
     ],
 )


### PR DESCRIPTION
Python 2 is end of life'd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/py-toxcore-c/48)
<!-- Reviewable:end -->
