### PR TITLE
Fix warning about empty statements (";") after macro calls.

### DIFF
--- a/pytox/av.c
+++ b/pytox/av.c
@@ -727,7 +727,7 @@ void ToxAVCore_install_dict(void)
 #define SET(name)                                           \
     PyObject* obj_##name = PyLong_FromLong(TOXAV_##name);   \
     PyDict_SetItemString(dict, #name, obj_##name);          \
-    Py_DECREF(obj_##name);
+    Py_DECREF(obj_##name)
 
     PyObject* dict = PyDict_New();
     SET(FRIEND_CALL_STATE_ERROR);

--- a/pytox/util.h
+++ b/pytox/util.h
@@ -28,11 +28,11 @@
 
 extern PyObject* ToxOpError;
 
-#define CHECK_TOX(self)                                             \
-  if ((self)->tox == NULL) {                                        \
+#define CHECK_TOX(SELF)                                             \
+  do { if ((SELF)->tox == NULL) {                                   \
     PyErr_SetString(ToxOpError, "toxcore object not initialised."); \
     return NULL;                                                    \
-  }
+  } } while (0)
 
 #if PY_MAJOR_VERSION < 3
   #define PYSTRING_FromString PyString_FromString


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/py-toxcore-c/50)
<!-- Reviewable:end -->
