### PR TITLE
Add support for toxcore built with autotools.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:16.04
-MAINTAINER iphydf@gmail.com
+FROM ubuntu:18.04
+LABEL maintainer="iphydf@gmail.com"
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y ca-certificates cmake gcc g++ git libopus-dev libsodium-dev libvpx-dev pkg-config python-dev \
@@ -11,7 +11,7 @@ COPY pytox /build/pytox/
 
 WORKDIR /build
 RUN git clone https://github.com/TokTok/c-toxcore /build/c-toxcore \
- && cmake -B/build/c-toxcore/_build -H/build/c-toxcore -DBOOTSTRAP_DAEMON=OFF \
+ && cmake -B/build/c-toxcore/_build -H/build/c-toxcore -DBOOTSTRAP_DAEMON=OFF -DMUST_BUILD_TOXAV=ON \
  && make -C/build/c-toxcore/_build install -j"$(nproc)" \
  && python setup.py install \
  && rm -r /build/*

--- a/pytox/util.c
+++ b/pytox/util.c
@@ -69,7 +69,9 @@ void PyStringUnicode_AsStringAndSize(PyObject* object, const char** str,
     Py_ssize_t* len)
 {
 #if PY_MAJOR_VERSION < 3
-    PyString_AsStringAndSize(object, str, len);
+    char *mstr;
+    PyString_AsStringAndSize(object, &mstr, len);
+    *str = mstr;
 #else
 # if PY_MINOR_VERSION == 2
     *str = (char *)PyUnicode_AS_DATA(object);


### PR DESCRIPTION
autotools builds toxcore and toxav as separate libs. This adds support
for both ways of having toxcore installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/py-toxcore-c/54)
<!-- Reviewable:end -->
