### PR TITLE
cleanup: Fix invalid function pointer cast.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run: apt-get update
       - run: DEBIAN_FRONTEND=noninteractive
           apt-get install -y --no-install-recommends
+          ca-certificates
           gcc
           g++
           cmake
@@ -29,9 +30,9 @@ jobs:
           pkg-config
           python3-dev
           python3-setuptools
-      - run: git clone --depth=1 git://github.com/TokTok/c-toxcore
+      - run: git clone --depth=1 https://github.com/TokTok/c-toxcore
       - run: cd c-toxcore;
-          . .travis/flags-gcc.sh;
+          . .github/scripts/flags-gcc.sh;
           add_flag -fsanitize=address;
           cmake -H. -B_build -GNinja
           -DCMAKE_C_FLAGS="$C_FLAGS"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.31-third_party
+    image: toxchat/toktok-stack:0.0.31-release
     cpu: 2
     memory: 6G
   configure_script:
@@ -9,5 +9,4 @@ cirrus-ci_task:
   test_all_script:
     - cd /src/workspace && bazel test -k
         --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
-        --config=release
         //py_toxcore_c/...

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,5 +12,4 @@ branches:
       required_status_checks:
         contexts:
           - "cirrus-ci"
-          - "Codacy Static Code Analysis"
           - "code-review/reviewable"

--- a/pytox/av.c
+++ b/pytox/av.c
@@ -347,13 +347,12 @@ static int ToxAVCore_init(ToxAVCore *self, PyObject *args, PyObject *kwds) {
   return init_helper(self, args);
 }
 
-static int ToxAVCore_dealloc(ToxAVCore *self) {
+static void ToxAVCore_dealloc(ToxAVCore *self) {
   if (self->av) {
     Py_DECREF(self->core);
     toxav_kill(self->av);
     self->av = NULL;
   }
-  return 0;
 }
 
 static PyObject *ToxAVCore_call(ToxAVCore *self, PyObject *args) {
@@ -558,12 +557,12 @@ static PyObject *ToxAVCore_get_tox(ToxAVCore *self, PyObject *args) {
   return self->core;
 }
 
-static PyObject *ToxAVCore_iteration_interval(ToxAVCore *self) {
+static PyObject *ToxAVCore_iteration_interval(ToxAVCore *self, PyObject *args) {
   uint32_t interval = toxav_iteration_interval(self->av);
   return PyLong_FromLong(interval);
 }
 
-static PyObject *ToxAVCore_iterate(ToxAVCore *self) {
+static PyObject *ToxAVCore_iterate(ToxAVCore *self, PyObject *args) {
   toxav_iterate(self->av);
   Py_RETURN_NONE;
 }

--- a/pytox/av.h
+++ b/pytox/av.h
@@ -29,7 +29,7 @@
 #include <vpx/vpx_image.h>
 
 /* ToxAV definition */
-typedef struct {
+typedef struct ToxAVCore {
   PyObject_HEAD PyObject *core;
   ToxAV *av;
   uint32_t i_w, i_h;

--- a/pytox/core.c
+++ b/pytox/core.c
@@ -323,12 +323,11 @@ static int ToxCore_init(ToxCore *self, PyObject *args, PyObject *kwds) {
   return init_helper(self, args);
 }
 
-static int ToxCore_dealloc(ToxCore *self) {
+static void ToxCore_dealloc(ToxCore *self) {
   if (self->tox) {
     tox_kill(self->tox);
     self->tox = NULL;
   }
-  return 0;
 }
 
 static PyObject *ToxCore_callback_stub(ToxCore *self, PyObject *args) {

--- a/pytox/core.h
+++ b/pytox/core.h
@@ -28,7 +28,7 @@
 #include <tox/tox.h>
 
 /* ToxAV definition */
-typedef struct {
+typedef struct ToxCore {
   PyObject_HEAD Tox *tox;
 } ToxCore;
 


### PR DESCRIPTION
Casting from `void(*)(T*)` to `void(*)(U*)` is ok, but casting to
`void(*)(U*,U*)` is not. The number and size of the parameters and return
type must be the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/py-toxcore-c/70)
<!-- Reviewable:end -->
