### PR TITLE
fix: fatal error: msgpack.h: No such file or directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
  libopus-dev \
  libsodium-dev \
  libvpx-dev \
+ libmsgpack-dev \
  ninja-build \
  pkg-config \
  python3 \


### PR DESCRIPTION
Hi, Met a failure in build process, and patched lost package.

`
...
[26/71] Building C object CMakeFiles/toxcore_shared.dir/toxcore/events/conference_connected.c.o
FAILED: CMakeFiles/toxcore_shared.dir/toxcore/events/conference_connected.c.o 
/usr/bin/cc -Dtoxcore_shared_EXPORTS -I/usr/include/opus -isystem /usr/include/opus  -fPIC   -std=c99 -MD -MT CMakeFiles/toxcore_shared.dir/toxcore/events/conference_connected.c.o -MF CMakeFiles/toxcore_shared.dir/toxcore/events/conference_connected.c.o.d -o CMakeFiles/toxcore_shared.dir/toxcore/events/conference_connected.c.o   -c ../toxcore/events/conference_connected.c
In file included from ../toxcore/events/conference_connected.c:5:
../toxcore/events/events_alloc.h:8:10: fatal error: msgpack.h: No such file or directorydcdc
    8 | #include <msgpack.h>
      |          ^~~~~~~~~~~
compilation terminated.
[27/71] Building C object CMakeFiles/toxcore_shared.dir/toxcore/Messenger.c.o
[28/71] Building C object CMakeFiles/toxcore_shared.dir/toxcore/group.c.o
...
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/py-toxcore-c/77)
<!-- Reviewable:end -->
