### PR TITLE
cleanup: Add explicit return types in tests.

### DIFF
--- a/test/auto_tests/self_connection_status_test.py
+++ b/test/auto_tests/self_connection_status_test.py
@@ -22,7 +22,7 @@ class TestTox(core.Tox_Ptr):
 
 
 class AutoTest(unittest.TestCase):
-    def test_connection_status_cb(self):
+    def test_connection_status_cb(self) -> None:
         with TestTox(None) as tox1:
             with TestTox(None) as tox2:
                 # Test that exceptions can pass through C code.

--- a/test/tox_options_test.py
+++ b/test/tox_options_test.py
@@ -5,13 +5,13 @@ from pytox import common
 
 
 class ToxOptionsTest(unittest.TestCase):
-    def test_options(self):
+    def test_options(self) -> None:
         opts = c.Tox_Options_Ptr()
         self.assertTrue(opts.ipv6_enabled)
         opts.ipv6_enabled = False
         self.assertFalse(opts.ipv6_enabled)
 
-    def test_use_after_free(self):
+    def test_use_after_free(self) -> None:
         with c.Tox_Options_Ptr() as opts:
             saved_opts = opts
         with self.assertRaises(common.UseAfterFreeException):

--- a/test/tox_test.py
+++ b/test/tox_test.py
@@ -5,28 +5,28 @@ from pytox import common
 
 
 class ToxTest(unittest.TestCase):
-    def test_version(self):
+    def test_version(self) -> None:
         self.assertEqual(len(c.VERSION.split(".")), 3)
 
-    def test_options(self):
+    def test_options(self) -> None:
         opts = c.Tox_Options_Ptr()
         self.assertTrue(opts.ipv6_enabled)
         opts.ipv6_enabled = False
         self.assertFalse(opts.ipv6_enabled)
 
-    def test_use_after_free(self):
+    def test_use_after_free(self) -> None:
         opts = c.Tox_Options_Ptr()
         with self.assertRaises(common.UseAfterFreeException):
             with c.Tox_Ptr(opts) as tox:
                 saved_tox = tox
             print(saved_tox.address)
 
-    def test_address(self):
+    def test_address(self) -> None:
         opts = c.Tox_Options_Ptr()
         with c.Tox_Ptr(opts) as tox:
             self.assertEqual(tox.address, tox.address)
 
-    def test_public_key_is_address_prefix(self):
+    def test_public_key_is_address_prefix(self) -> None:
         opts = c.Tox_Options_Ptr()
         with c.Tox_Ptr(opts) as tox:
             self.assertEqual(
@@ -34,16 +34,16 @@ class ToxTest(unittest.TestCase):
                 tox.address[:36].hex(),
             )
 
-    def test_public_key_is_not_secret_key(self):
+    def test_public_key_is_not_secret_key(self) -> None:
         opts = c.Tox_Options_Ptr()
         with c.Tox_Ptr(opts) as tox:
             self.assertNotEqual(tox.public_key, tox.secret_key)
 
-    def test_savedata_contains_secret_key(self):
+    def test_savedata_contains_secret_key(self) -> None:
         with c.Tox_Ptr(None) as tox:
             self.assertIn(tox.secret_key, tox.savedata)
 
-    def test_set_name(self):
+    def test_set_name(self) -> None:
         with c.Tox_Ptr(None) as tox:
             self.assertEqual(tox.name, b"")
             tox.name = b"iphy"
@@ -53,7 +53,7 @@ class ToxTest(unittest.TestCase):
             with self.assertRaises(c.ApiException):
                 tox.name = b"x" * (c.MAX_NAME_LENGTH + 1)
 
-    def test_set_status_message(self):
+    def test_set_status_message(self) -> None:
         with c.Tox_Ptr(None) as tox:
             self.assertEqual(tox.status_message, b"")
             tox.status_message = b"pytox is cool now"
@@ -63,7 +63,7 @@ class ToxTest(unittest.TestCase):
             with self.assertRaises(c.ApiException):
                 tox.status_message = b"x" * (c.MAX_STATUS_MESSAGE_LENGTH + 1)
 
-    def test_set_status(self):
+    def test_set_status(self) -> None:
         with c.Tox_Ptr(None) as tox:
             self.assertEqual(tox.status, c.TOX_USER_STATUS_NONE)
             tox.status = c.TOX_USER_STATUS_AWAY
@@ -71,7 +71,7 @@ class ToxTest(unittest.TestCase):
             tox.status = 50  # setting it to an invalid value has no effect
             self.assertEqual(tox.status, c.TOX_USER_STATUS_AWAY)
 
-    def test_friend_add(self):
+    def test_friend_add(self) -> None:
         with c.Tox_Ptr(None) as tox1:
             with c.Tox_Ptr(None) as tox2:
                 tox1.friend_add(tox2.address, b"hello there!")
@@ -79,7 +79,7 @@ class ToxTest(unittest.TestCase):
                 with self.assertRaises(common.LengthException):
                     tox2.friend_add(tox1.public_key, b"oh no!")
 
-    def test_friend_delete(self):
+    def test_friend_delete(self) -> None:
         with c.Tox_Ptr(None) as tox1:
             with c.Tox_Ptr(None) as tox2:
                 tox1.friend_add(tox2.address, b"hello there!")

--- a/test/toxav_test.py
+++ b/test/toxav_test.py
@@ -4,7 +4,7 @@ import pytox.toxav.toxav as av
 
 
 class AvTest(unittest.TestCase):
-    def test_version(self):
+    def test_version(self) -> None:
         with self.assertRaises(av.ApiException) as ex:
             av.Toxav_Ptr(None)
         self.assertEqual(ex.exception.error, av.TOXAV_ERR_NEW_NULL)

--- a/test/toxencryptsave_test.py
+++ b/test/toxencryptsave_test.py
@@ -5,19 +5,19 @@ from pytox.toxencryptsave import toxencryptsave as c
 
 
 class ToxencryptsaveTest(unittest.TestCase):
-    def test_encrypt_decrypt(self):
+    def test_encrypt_decrypt(self) -> None:
         with c.Tox_Pass_Key_Ptr(b"hello") as pk:
             self.assertNotEqual(pk.encrypt(b"hello world"), b"hello world")
             self.assertEqual(pk.decrypt(pk.encrypt(b"hello world")),
                              b"hello world")
 
-    def test_encrypt_decrypt_with_correct_salt(self):
+    def test_encrypt_decrypt_with_correct_salt(self) -> None:
         with c.Tox_Pass_Key_Ptr(b"hello", b"a" * 32) as pk1:
             with c.Tox_Pass_Key_Ptr(b"hello", b"a" * 32) as pk2:
                 self.assertEqual(pk2.decrypt(pk1.encrypt(b"hello world")),
                                  b"hello world")
 
-    def test_encrypt_decrypt_with_wrong_salt(self):
+    def test_encrypt_decrypt_with_wrong_salt(self) -> None:
         with c.Tox_Pass_Key_Ptr(b"hello", b"a" * 32) as pk1:
             with c.Tox_Pass_Key_Ptr(b"hello", b"b" * 32) as pk2:
                 with self.assertRaises(c.ApiException) as ex:
@@ -25,7 +25,7 @@ class ToxencryptsaveTest(unittest.TestCase):
                 self.assertEqual(ex.exception.error.name,
                                  c.TOX_ERR_DECRYPTION_FAILED.name)
 
-    def test_salt_too_small(self):
+    def test_salt_too_small(self) -> None:
         with self.assertRaises(common.LengthException):
             c.Tox_Pass_Key_Ptr(b"hello", b"world")
 


### PR DESCRIPTION
To make mypy happy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/py-toxcore-c/96)
<!-- Reviewable:end -->
